### PR TITLE
Allow user to specify library name for Interop

### DIFF
--- a/SharpPhysFS/PhysFS.cs
+++ b/SharpPhysFS/PhysFS.cs
@@ -32,6 +32,12 @@ namespace SharpPhysFS
       Init(argv0);
     }
 
+    public PhysFS(string argv0, string libname)
+    {
+      interop = new Interop(libname);
+      Init(argv0);
+    }
+
     static T FromPtr<T>(IntPtr ptr)
     {
       return (T)Marshal.PtrToStructure(ptr, typeof(T));


### PR DESCRIPTION
Currently, there is no way to specify a custom library name. This pull request solves that.